### PR TITLE
Set the `isser` in the mediaquery listener

### DIFF
--- a/dist/ember-responsive.js
+++ b/dist/ember-responsive.js
@@ -317,6 +317,7 @@
 
       var listener = function(matcher) {
         _this.set(name, matcher);
+        _this.set(isser, matcher.matches);
 
         if (matcher.matches) {
           _this.get('matches').add(name);
@@ -327,11 +328,6 @@
 
       matcher.addListener(listener);
       listener(matcher);
-
-      // Define a corresponding "isser" which is prettier to look at and type
-      Ember.defineProperty(this, isser, Ember.computed(function() {
-        return this.get(name).matches;
-      }).property(name));
     }
   });
 })(window.Ember);

--- a/dist/ember-responsive.js
+++ b/dist/ember-responsive.js
@@ -266,6 +266,8 @@
       return new Ember.Set();
     }.property(),
 
+    listeners: {},
+
    /**
     * The matcher to use for testing media queries.
     *
@@ -316,7 +318,17 @@
           _this = this;
 
       var listener = function(matcher) {
+
+        // Make sure than set(name, matcher) and notifyPropertyChange(name) notifications
+        // are merged so only one notification is sent,
+        // even the first tinm this listener is called
+        _this.beginPropertyChanges();
+
         _this.set(name, matcher);
+        _this.notifyPropertyChange(name);
+
+        _this.endPropertyChanges();
+
         _this.set(isser, matcher.matches);
 
         if (matcher.matches) {
@@ -325,7 +337,7 @@
           _this.get('matches').remove(name);
         }
       };
-
+      this.get('listeners')[name] = listener;
       matcher.addListener(listener);
       listener(matcher);
     }

--- a/lib/media.js
+++ b/lib/media.js
@@ -138,9 +138,18 @@
           _this = this;
 
       var listener = function(matcher) {
+
+        // Make sure than set(name, matcher) and notifyPropertyChange(name) notifications
+        // are merged so only one notification is sent,
+        // even the first tinm this listener is called
+        _this.beginPropertyChanges();
+
         _this.set(name, matcher);
-        _this.set(isser, matcher.matches);
         _this.notifyPropertyChange(name);
+
+        _this.endPropertyChanges();
+
+        _this.set(isser, matcher.matches);
 
         if (matcher.matches) {
           _this.get('matches').add(name);

--- a/lib/media.js
+++ b/lib/media.js
@@ -147,15 +147,15 @@
 
         // Make sure than set(name, matcher) and notifyPropertyChange(name) notifications
         // are merged so only one notification is sent,
-        // even the first tinm this listener is called
+        // even the first time this listener is called
         _this.beginPropertyChanges();
 
         _this.set(name, matcher);
         _this.notifyPropertyChange(name);
 
-        _this.endPropertyChanges();
-
         _this.set(isser, matcher.matches);
+
+        _this.endPropertyChanges();
 
         if (matcher.matches) {
           _this.get('matches').add(name);

--- a/lib/media.js
+++ b/lib/media.js
@@ -137,6 +137,7 @@
 
       var listener = function(matcher) {
         _this.set(name, matcher);
+        _this.set(isser, matcher.matches);
 
         if (matcher.matches) {
           _this.get('matches').add(name);
@@ -147,11 +148,6 @@
 
       matcher.addListener(listener);
       listener(matcher);
-
-      // Define a corresponding "isser" which is prettier to look at and type
-      Ember.defineProperty(this, isser, Ember.computed(function() {
-        return this.get(name).matches;
-      }).property(name));
     }
   });
 })(window.Ember);

--- a/lib/media.js
+++ b/lib/media.js
@@ -86,6 +86,12 @@
       return new Ember.Set();
     }.property(),
 
+    /**
+     * A hash of listeners indexed by their matcher's names
+     *
+     * @property
+     * @type Object
+     */
     listeners: {},
 
    /**

--- a/lib/media.js
+++ b/lib/media.js
@@ -86,6 +86,8 @@
       return new Ember.Set();
     }.property(),
 
+    listeners: {},
+
    /**
     * The matcher to use for testing media queries.
     *
@@ -138,6 +140,7 @@
       var listener = function(matcher) {
         _this.set(name, matcher);
         _this.set(isser, matcher.matches);
+        _this.notifyPropertyChange(name);
 
         if (matcher.matches) {
           _this.get('matches').add(name);
@@ -145,7 +148,7 @@
           _this.get('matches').remove(name);
         }
       };
-
+      this.get('listeners')[name] = listener;
       matcher.addListener(listener);
       listener(matcher);
     }

--- a/test/media-test.js
+++ b/test/media-test.js
@@ -50,17 +50,20 @@ test('matcher\'s name property can be bound to', function() {
     subject = Ember.Responsive.Media.create(),
     observer = sinon.spy();
 
-  subject.match(name, 'query');
   subject.addObserver(name, this, observer);
+  //First call
+  subject.match(name, 'query');
 
   listener = subject.get('listeners')[name];
 
   matcher = subject.get(name);
   matcher.matches = true;
+  //Second call
   listener(matcher);
 
   matcher.matches = false;
+  //Third call
   listener(matcher);
 
-  ok(observer.callCount == 2);
+  ok(observer.callCount == 3);
 });

--- a/test/media-test.js
+++ b/test/media-test.js
@@ -44,3 +44,23 @@ test('classNames is correctly bound to the matches property', function() {
   subject.match('one', 'none');
   equal('media-two', subject.get('classNames'));
 });
+
+test('matcher\'s name property can be bound to', function() {
+  var listener, matcher, name = 'somethingUnique',
+    subject = Ember.Responsive.Media.create(),
+    observer = sinon.spy();
+
+  subject.match(name, 'query');
+  subject.addObserver(name, this, observer);
+
+  listener = subject.get('listeners')[name];
+
+  matcher = subject.get(name);
+  matcher.matches = true;
+  listener(matcher);
+
+  matcher.matches = false;
+  listener(matcher);
+
+  ok(observer.callCount == 2);
+});


### PR DESCRIPTION
All the corresponding issers were never recomputed because the object they are depending on never change.

I don't think there was lot of value for those properties to be computed anyway.

Add a `listeners` property, for the two following reasons:
- It makes testing easier
- It paves the way for being able to dynamically unmatch queries.
