### PR TITLE
Avoid Ember String.prototype extension usage

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -112,8 +112,9 @@
     * @type      string
     */
     classNames: function() {
+      var dasherize = Ember.String.dasherize;
       return this.get('matches').map(function(name) {
-        return 'media-' + name.dasherize();
+        return 'media-' + dasherize(name);
       }).join(' ');
     }.property('matches.[]'),
 
@@ -139,13 +140,14 @@
     * @method  match
     */
     match: function(name, query) {
-      var matcher = this.get('mql')(query),
-          isser = 'is' + name.classify(),
+      var classify = Ember.String.classify,
+          matcher = this.get('mql')(query),
+          isser = 'is' + classify(name),
           _this = this;
 
       var listener = function(matcher) {
 
-        // Make sure than set(name, matcher) and notifyPropertyChange(name) notifications
+        // Make sure that set(name, matcher) and notifyPropertyChange(name) notifications
         // are merged so only one notification is sent,
         // even the first time this listener is called
         _this.beginPropertyChanges();


### PR DESCRIPTION
It's probably fine for 90%+ of the ember usage out there, but it's technically not safe to rely on the existence of Ember's String.prototype extensions (`.dasherize`, `.classify`, etc.). This PR removes that potentially unsafe usage.
