### PR TITLE
Specify support for Ember >1.5.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-responsive",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "main": "dist/ember-responsive.js",
   "authors": [
     "Jonathan Geiger <geiger@freshbooks.com>",

--- a/dist/doc/classes/Ember.Application.initializer.html
+++ b/dist/doc/classes/Ember.Application.initializer.html
@@ -19,7 +19,7 @@
             
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 0.2.8</em>
+            <em>API Docs for: 0.2.11</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/dist/doc/classes/Ember.Application.responsive.html
+++ b/dist/doc/classes/Ember.Application.responsive.html
@@ -19,7 +19,7 @@
             
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 0.2.8</em>
+            <em>API Docs for: 0.2.11</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/dist/doc/classes/Ember.Responsive.Media.html
+++ b/dist/doc/classes/Ember.Responsive.Media.html
@@ -19,7 +19,7 @@
             
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 0.2.8</em>
+            <em>API Docs for: 0.2.11</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/dist/doc/data.json
+++ b/dist/doc/data.json
@@ -2,7 +2,7 @@
     "project": {
         "name": "ember-responsive",
         "description": "Easy responsive layouts with Ember",
-        "version": "0.2.8",
+        "version": "0.2.11",
         "url": "https://freshbooks.github.io/ember-responsive/"
     },
     "files": {

--- a/dist/doc/files/lib_initializer.js.html
+++ b/dist/doc/files/lib_initializer.js.html
@@ -19,7 +19,7 @@
             
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 0.2.8</em>
+            <em>API Docs for: 0.2.11</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/dist/doc/files/lib_media.js.html
+++ b/dist/doc/files/lib_media.js.html
@@ -19,7 +19,7 @@
             
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 0.2.8</em>
+            <em>API Docs for: 0.2.11</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/dist/doc/files/lib_responsive.js.html
+++ b/dist/doc/files/lib_responsive.js.html
@@ -19,7 +19,7 @@
             
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 0.2.8</em>
+            <em>API Docs for: 0.2.11</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/dist/doc/index.html
+++ b/dist/doc/index.html
@@ -19,7 +19,7 @@
             
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 0.2.8</em>
+            <em>API Docs for: 0.2.11</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/dist/doc/modules/ember-responsive.html
+++ b/dist/doc/modules/ember-responsive.html
@@ -19,7 +19,7 @@
             
         </div>
         <div class="yui3-u-1-4 version">
-            <em>API Docs for: 0.2.8</em>
+            <em>API Docs for: 0.2.11</em>
         </div>
     </div>
     <div id="bd" class="yui3-g">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-responsive",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Easy responsive layouts with Ember",
   "scripts": {
     "test": "grunt test",


### PR DESCRIPTION
Explicitly capped at versions that are currently released. This'll force us to check every major & minor release for compatibility.
