### PR TITLE
swap `Ember.Set` for `Ember.NativeArray` - closes #20

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -79,11 +79,11 @@
     * A set of matching matchers.
     *
     * @property  matches
-    * @type      Ember.Set
-    * @default   Ember.Set
+    * @type      Ember.NativeArray
+    * @default   Ember.NativeArray
     */
     matches: function() {
-      return new Ember.Set();
+      return Ember.A();
     }.property(),
 
     /**
@@ -150,9 +150,9 @@
         _this.set(isser, matcher.matches);
 
         if (matcher.matches) {
-          _this.get('matches').add(name);
+          _this.get('matches').addObject(name);
         } else {
-          _this.get('matches').remove(name);
+          _this.get('matches').removeObject(name);
         }
       }
       this.get('listeners')[name] = listener;


### PR DESCRIPTION
As of Ember 1.8, `Ember.Set` will be deprecated. `Ember.NativeArray`'s
`#addObject` and `#removeObject` will only add if the item isn't found
in the array and will remove all occurances.

See http://emberjs.com/api/classes/Ember.NativeArray.html#method_addObject
and http://emberjs.com/api/classes/Ember.NativeArray.html#method_removeObject for more.
