### PR TITLE
Install Default Breakpoints When Package Installed

### DIFF
--- a/blueprints/ember-responsive/files/__root__/breakpoints.js
+++ b/blueprints/ember-responsive/files/__root__/breakpoints.js
@@ -1,0 +1,8 @@
+// Here are some example breakpoints that you might register. Customize, and
+// add more as fit for your project.
+export default {
+  mobile:  '(max-width: 768px)',
+  tablet:  '(min-width: 769px) and (max-width: 992px)',
+  desktop: '(min-width: 993px) and (max-width: 1200px)',
+  jumbo:   '(min-width: 1201px)'
+};

--- a/blueprints/ember-responsive/index.js
+++ b/blueprints/ember-responsive/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  // no-op!
+  normalizeEntityName: function() {}
+};


### PR DESCRIPTION
In the past we've been a bit of a jerk and just warned people that they
should define an `app/breakpoints.js` file. Let's be nice and set up
default breakpoints to use as examples.