### PR TITLE
In prior versions of Ember initializers have taken two arguments

### DIFF
--- a/addon/initializers/responsive.js
+++ b/addon/initializers/responsive.js
@@ -3,7 +3,8 @@
  *
  * Injects the media service in all controllers route components and views
  */
-export function initialize(application) {
+export function initialize() {
+  let application = arguments[1] || arguments[0];
   application.inject('controller', 'media', 'service:media');
   application.inject('component', 'media', 'service:media');
   application.inject('route', 'media', 'service:media');


### PR DESCRIPTION
That PR follow the advice provided by http://emberjs.com/deprecations/v2.x/#toc_initializer-arity to support older version of ember