### PR TITLE
Use `getOwner` and polyfill to get around Ember 2.3's deprecation

### DIFF
--- a/addon/media.js
+++ b/addon/media.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
+import getOwner from 'ember-getowner-polyfill';
+
 /**
 * Handles detecting and responding to media queries.
 *
@@ -117,7 +119,7 @@ export default Ember.Service.extend({
   },
 
   breakpoints: Ember.computed(function() {
-    return this.container.lookupFactory('breakpoints:main');
+    return getOwner(this)._lookupFactory('breakpoints:main');
   }),
 
   /**

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
+    "ember-getowner-polyfill": "1.0.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "~0.0.8"
   },


### PR DESCRIPTION
Similar implementation to https://github.com/freshbooks/ember-responsive/pull/51, but supports older Ember versions as well
