### PR TITLE
Fixes test suite

### DIFF
--- a/addon/media.js
+++ b/addon/media.js
@@ -106,7 +106,7 @@ export default Ember.Service.extend({
    *
    */
   init: function() {
-    const breakpoints = this.container.lookupFactory('breakpoints:main');
+    const breakpoints = this.get('breakpoints');
     if (breakpoints) {
       for (var name in breakpoints) {
         if (breakpoints.hasOwnProperty(name)) {
@@ -115,6 +115,10 @@ export default Ember.Service.extend({
       }
     }
   },
+
+  breakpoints: Ember.computed(function() {
+    return this.container.lookupFactory('breakpoints:main');
+  }),
 
   /**
   * A string composed of all the matching matchers' names, turned into

--- a/bower.json
+++ b/bower.json
@@ -5,11 +5,11 @@
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.2.1",
     "ember-load-initializers": "0.1.7",
-    "ember-qunit": "0.4.13",
+    "ember-qunit": "0.4.18",
     "ember-qunit-notifications": "0.1.0",
     "jquery": "^1.11.3",
-    "loader.js": "3.3.0",
-    "qunit": "~1.19.0",
+    "loader.js": "ember-cli/loader.js#3.4.0",
+    "qunit": "~1.20.0",
     "sinon": "http://sinonjs.org/releases/sinon-1.12.1.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "ember-cli": "1.13.8",
+    "ember-cli": "1.13.13",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.1.0",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.0.3",
-    "ember-cli-release": "0.2.7",
-    "ember-cli-sri": "^1.1.0",
+    "ember-cli-qunit": "^1.0.4",
+    "ember-cli-release": "0.2.8",
+    "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
@@ -41,7 +41,7 @@
     "media query"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -4,17 +4,19 @@ import destroyApp from '../helpers/destroy-app';
 
 export default function(name, options = {}) {
   module(name, {
-    beforeEach: function() {
+    beforeEach() {
       this.application = startApp();
+
       if (options.beforeEach) {
-        options.beforeEach.call(this, arguments);
+        options.beforeEach.apply(this, arguments);
       }
     },
 
-    afterEach: function() {
+    afterEach() {
       destroyApp(this.application);
+
       if (options.afterEach) {
-        options.afterEach.call(this, arguments);
+        options.afterEach.apply(this, arguments);
       }
     }
   });

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,4 +1,4 @@
-import Resolver from 'ember-resolver';
+import Resolver from 'ember/resolver';
 import config from '../../config/environment';
 
 const resolver = Resolver.create();

--- a/tests/unit/services/media-test.js
+++ b/tests/unit/services/media-test.js
@@ -1,22 +1,22 @@
 /* global sinon */
+
 import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
-
-moduleFor('service:media');
 
 const mediaRules = {
   mobile:  '(max-width: 768px)',
   jumbo:   '(min-width: 1201px)'
 };
 
+moduleFor('service:media', 'Unit | Service | media', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
 test('it matches on init', function(assert) {
 
   const subject = this.subject({
-    container: {
-      lookupFactory: () => {
-        return mediaRules;
-      }
-    },
+    breakpoints: mediaRules,
     match: sinon.stub()
   });
 
@@ -25,21 +25,21 @@ test('it matches on init', function(assert) {
 });
 
 test('matchers can be added dynamically', function(assert) {
-  var subject = this.subject({container: {lookupFactory: sinon.stub()}});
+  var subject = this.subject({ breakpoints: mediaRules });
   subject.match('all', 'not all');
 
   assert.equal(false, subject.get('all.matches'));
 });
 
 test('matchers have a corresponding isser', function(assert) {
-  var subject = this.subject({container: {lookupFactory: sinon.stub()}});
+  var subject = this.subject({ breakpoints: mediaRules });
   subject.match('mobile', 'not all');
 
   assert.equal(false, subject.get('isMobile'));
 });
 
 test('matches property returns matching matchers', function(assert) {
-  var subject = this.subject({container: {lookupFactory: sinon.stub()}});
+  var subject = this.subject({ breakpoints: mediaRules });
   subject.match('mobile', 'all');
   subject.match('all', 'all');
   subject.match('none', 'not all');
@@ -48,7 +48,7 @@ test('matches property returns matching matchers', function(assert) {
 });
 
 test('classNames property returns matching matchers as classes', function(assert) {
-  var subject = this.subject({container: {lookupFactory: sinon.stub()}});
+  var subject = this.subject({ breakpoints: mediaRules });
   subject.match('mobileDevice', 'all');
   subject.match('all', 'all');
   subject.match('none', 'not all');
@@ -57,7 +57,7 @@ test('classNames property returns matching matchers as classes', function(assert
 });
 
 test('classNames is correctly bound to the matches property', function(assert) {
-  var subject = this.subject({container: {lookupFactory: sinon.stub()}});
+  var subject = this.subject({ breakpoints: mediaRules });
  
   subject.match('one', 'all');
   assert.equal('media-one', subject.get('classNames'));
@@ -71,7 +71,7 @@ test('classNames is correctly bound to the matches property', function(assert) {
 
 test('matcher\'s isser property notifies upon change', function(assert) {
   var listener, matcher, name = 'somethingUnique',
-    subject = this.subject({container: {lookupFactory: sinon.stub()}}),
+    subject = this.subject({ breakpoints: mediaRules }),
     observer = sinon.spy();
 
   subject.addObserver('is'+Ember.String.classify(name), this, observer);


### PR DESCRIPTION
Ember beta/canary builds no longer allow `container.lookupFactory` modification after they're constructed.