### PR TITLE
Use fake, always-false matchMedia when not available (like in FastBoot)

### DIFF
--- a/addon/media.js
+++ b/addon/media.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import getOwner from 'ember-getowner-polyfill';
+import nullMatchMedia from './null-match-media';
 
 /**
 * Handles detecting and responding to media queries.
@@ -99,7 +100,7 @@ export default Ember.Service.extend({
   * @default   window.matchMedia
   * @private
   */
-  mql: window.matchMedia,
+  mql: detectMatchMedia(),
 
   /**
    * Initialize the service based on the breakpoints config
@@ -183,3 +184,11 @@ export default Ember.Service.extend({
     listener(matcher);
   }
 });
+
+function detectMatchMedia() {
+  if (typeof window === 'object' && window.matchMedia) {
+    return window.matchMedia;
+  }
+
+  return nullMatchMedia;
+}

--- a/addon/null-match-media.js
+++ b/addon/null-match-media.js
@@ -1,0 +1,10 @@
+/**
+ * Stub function that is `matchMedia` API compatible but always returns
+ * `false`. Useful for server-side environments like FastBoot where there
+ * is no viewport.
+ */
+export default function() {
+  return {
+    matches: false
+  };
+}


### PR DESCRIPTION
This is my first attempt at FastBoot compatibility. It just detects when `matchMedia` isn't available and returns a stub version that always never matches anything.