### PR TITLE
Remove use of private method `lookupFactory`

### DIFF
--- a/addon/media.js
+++ b/addon/media.js
@@ -109,6 +109,8 @@ export default Ember.Service.extend({
    */
   init: function() {
     const breakpoints = this.get('breakpoints');
+    const owner = getOwner(this);
+    owner.registerOptionsForType('breakpoints', { instantiate: false });
     if (breakpoints) {
       for (var name in breakpoints) {
         if (breakpoints.hasOwnProperty(name)) {
@@ -119,7 +121,7 @@ export default Ember.Service.extend({
   },
 
   breakpoints: Ember.computed(function() {
-    return getOwner(this)._lookupFactory('breakpoints:main');
+    return getOwner(this).lookup('breakpoints:main');
   }),
 
   /**


### PR DESCRIPTION
When the service is initialized, an option is registered for the
`breakpoint` type. This prevents the `lookup` method in `getOwner` from
instantiating the factory.