### PR TITLE
Fix set destroyed error

### DIFF
--- a/addon/media.js
+++ b/addon/media.js
@@ -166,6 +166,10 @@ export default Ember.Service.extend({
         isser = 'is' + classify(name);
 
     var listener = (matcher) => {
+      if (this.get('isDestroyed')) {
+        return;
+      }
+
       this.set(name, matcher);
       this.set(isser, matcher.matches);
 


### PR DESCRIPTION
During running acceptance tests on Ember Twiddle, if I resize the screen, I get the error message 'calling set on destroyed object'. I traced the issue to this addon.

This is a simple fix for that error.