### PR TITLE
Fix breaking initializer change

### DIFF
--- a/app/initializers/responsive.js
+++ b/app/initializers/responsive.js
@@ -1,0 +1,2 @@
+import responsive from 'ember-responsive/initializers/responsive';
+export default responsive;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-responsive",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "An ember-cli addon that give you a simple, Ember-aware way of dealing with media queries.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
The previous initializer change will make `^1.0.0` versions of ember break when
using npm install. `ember g ember-responsive` needs to be called, but that can
be part of a move to a new major version.

This change will allow existing `^1.0.0` versions to work and also update ahead of time for `2.x` versions. 

Addresses #81 

Thanks @kellyselden for pointing this out.