### PR TITLE
[WIP] Remove hardcoded defaults

### DIFF
--- a/app/breakpoints.js
+++ b/app/breakpoints.js
@@ -1,6 +1,0 @@
-export default {
-  mobile:  '(max-width: 768px)',
-  tablet:  '(min-width: 769px) and (max-width: 992px)',
-  desktop: '(min-width: 993px) and (max-width: 1200px)',
-  jumbo:   '(min-width: 1201px)'
-};

--- a/blueprints/ember-responsive/files/__root__/breakpoints.js
+++ b/blueprints/ember-responsive/files/__root__/breakpoints.js
@@ -1,5 +1,6 @@
 export default {
   mobile:  '(max-width: 767px)',
   tablet:  '(min-width: 768px) and (max-width: 991px)',
-  desktop: '(min-width: 992px) and (max-width: 1200px)'
+  desktop: '(min-width: 992px) and (max-width: 1200px)',
+  jumbo:   '(min-width: 1201px)'
 };


### PR DESCRIPTION
This commit removes app/breakpoints.js, which was a fallback default for
breakpoint configuration.

This addon already uses a blueprint to generate a `breakpoints.js` file
in the parent app or addon, which that parent can use to customize the
defaults. By also having this file in `app/breakpoints.js`, this
actually prevents parent _addons_ from being able to set a new default
for _their_ host apps - the end application must have a `breakpoints.js`
file within its own `app` directory.

By removing this file, addons can now use `ember-responsive` and provide
their own `app/breakpoints.js`, which would be used by their own
host apps.