### PR TITLE
optimize event listener by debouncing function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "6"
 
 sudo: false
 

--- a/addon/media.js
+++ b/addon/media.js
@@ -183,7 +183,7 @@ export default Ember.Service.extend({
 
     if (matcher.addListener) {
       matcher.addListener(function(matcher){
-        Ember.run(null, listener, matcher);
+        Ember.run.debounce(null, listener, matcher, 100);
       });
     }
     listener(matcher);


### PR DESCRIPTION
A case in  mobile app named [Yahoo! JAPAN](https://itunes.apple.com/jp/app/yahoo-japan-%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B9%E3%81%AB%E6%A4%9C%E7%B4%A2-%E5%BF%85%E8%A6%81%E3%81%AA%E6%83%85%E5%A0%B1%E3%81%8C%E3%81%93%E3%82%8C%E3%81%B2%E3%81%A8%E3%81%A4%E3%81%A7/id299147843?l=en&mt=8):

  the match listener triggered twice (event more times) when switch page by touching stacked icon (<img src="https://support.apple.com/library/content/dam/edam/applecare/images/en_US/il/ios10-safari-icon-tab-split.png" width="12" height="12" />), 
this will cause the component  re-instantiated. 