### PR TITLE
Bump dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,13 +1,8 @@
 {
   "name": "ember-responsive",
   "dependencies": {
-    "ember": "2.1.0",
-    "ember-cli-shims": "0.0.6",
-    "ember-cli-test-loader": "0.2.1",
-    "ember-load-initializers": "0.1.7",
-    "ember-qunit": "0.4.18",
-    "loader.js": "ember-cli/loader.js#3.4.0",
-    "qunit": "~1.20.0",
+    "ember-load-initializers": "1.0.0",
+    "ember-qunit": "1.0.0",
     "sinon": "http://sinonjs.org/releases/sinon-1.12.1.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,21 +19,23 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "ember-cli": "1.13.15",
-    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli": "2.13.2",
+    "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.4.3",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.0.4",
+    "ember-cli-qunit": "^4.0.0",
+    "ember-cli-shims": "1.1.0",
+    "ember-cli-test-loader": "2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-resolver": "^2.0.3",
-    "ember-try": "~0.0.8"
+    "ember-resolver": "^4.1.0",
+    "loader.js": "4.4.0"
   },
   "keywords": [
     "ember-addon",
     "media query"
   ],
   "dependencies": {
-    "ember-cli-babel": "^6.1.0",
+    "ember-cli-babel": "^6.4.1",
     "ember-getowner-polyfill": "^1.1.1"
   },
   "ember-addon": {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,6 +1,6 @@
 import resolver from './helpers/resolver';
-import {
-  setResolver
-} from 'ember-qunit';
+import { setResolver } from 'ember-qunit';
+import { start } from 'ember-cli-qunit';
 
 setResolver(resolver);
+start();


### PR DESCRIPTION
This updates ember-cli from 1.13 to 2.13, removes ember and qunit from bower, moves ember-cli-shims and loader.js from bower into npm and updates any dependencies that are behind.