### PR TITLE
do not add matchMedia listener in test environment

### DIFF
--- a/addon/media.js
+++ b/addon/media.js
@@ -139,6 +139,15 @@ export default Ember.Service.extend({
       return `media-${dasherize(name)}`;
     }).join(' ');
   }),
+  
+  /**
+  * A boolean used to determine if a matchMedia listener should be added.
+  * In test environment, we do not want to add a listener, as for large test runs, it creates a memory leak
+  */
+  isTestEnv: Ember.computed(function() {
+    let config = Ember.getOwner(this).resolveRegistration('config:environment');
+    return config.environment === 'test';
+  }),
 
   /**
   * Adds a new matcher to the list.
@@ -181,7 +190,7 @@ export default Ember.Service.extend({
     };
     this.get('listeners')[name] = listener;
 
-    if (matcher.addListener) {
+    if (matcher.addListener && !this.get('isTestEnv')) {
       matcher.addListener(function(matcher){
         Ember.run(null, listener, matcher);
       });


### PR DESCRIPTION
As discussed in https://github.com/freshbooks/ember-responsive/issues/101, the listeners being added are not being torn down in between test runs. This is causing a memory leak, which for large test runs causes the browser to run out of memory and crash.