### PR TITLE
[RFC][NI] Fix breakpoints coherency across addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ After that, simply register the breakpoints that are pertinent to your applicati
 
 ```js
 export default {
-  mobile:  '(max-width: 768px)',
-  tablet:  '(min-width: 769px) and (max-width: 992px)',
+  mobile:  '(max-width: 767px)',
+  tablet:  '(min-width: 768px) and (max-width: 992px)',
   desktop: '(min-width: 993px) and (max-width: 1200px)',
   jumbo:   '(min-width: 1201px)'
 };

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ After that, simply register the breakpoints that are pertinent to your applicati
 ```js
 export default {
   mobile:  '(max-width: 767px)',
-  tablet:  '(min-width: 768px) and (max-width: 992px)',
-  desktop: '(min-width: 993px) and (max-width: 1200px)',
+  tablet:  '(min-width: 768px) and (max-width: 991px)',
+  desktop: '(min-width: 992px) and (max-width: 1200px)',
   jumbo:   '(min-width: 1201px)'
 };
 ```

--- a/addon/media.js
+++ b/addon/media.js
@@ -15,8 +15,8 @@ const { dasherize, classify } = Ember.String;
 *
 * ```javascript
 * media = Ember.Responsive.Media.create();
-* media.match('mobile', '(max-width: 768px)');
-* media.match('desktop', '(min-width: 769px)');
+* media.match('mobile', '(max-width: 767px)');
+* media.match('desktop', '(min-width: 768px)');
 * ```
 *
 * **Testing the media query matchers**
@@ -29,7 +29,7 @@ const { dasherize, classify } = Ember.String;
 *
 * ```javascript
 * media = Ember.Responsive.Media.create();
-* media.match('mobile', '(max-width: 768px)');
+* media.match('mobile', '(max-width: 767px)');
 * media.match('desktop', '(min-width: 769px)');
 *
 * // There are convenient "isser" properties defined...

--- a/addon/media.js
+++ b/addon/media.js
@@ -30,7 +30,7 @@ const { dasherize, classify } = Ember.String;
 * ```javascript
 * media = Ember.Responsive.Media.create();
 * media.match('mobile', '(max-width: 767px)');
-* media.match('desktop', '(min-width: 769px)');
+* media.match('desktop', '(min-width: 768px)');
 *
 * // There are convenient "isser" properties defined...
 * if (media.get('isMobile')) {

--- a/app/breakpoints.js
+++ b/app/breakpoints.js
@@ -1,6 +1,6 @@
 export default {
   mobile:  '(max-width: 767px)',
-  tablet:  '(min-width: 768px) and (max-width: 992px)',
-  desktop: '(min-width: 993px) and (max-width: 1200px)',
+  tablet:  '(min-width: 768px) and (max-width: 991px)',
+  desktop: '(min-width: 992px) and (max-width: 1200px)',
   jumbo:   '(min-width: 1201px)'
 };

--- a/app/breakpoints.js
+++ b/app/breakpoints.js
@@ -1,6 +1,6 @@
 export default {
-  mobile:  '(max-width: 768px)',
-  tablet:  '(min-width: 769px) and (max-width: 992px)',
+  mobile:  '(max-width: 767px)',
+  tablet:  '(min-width: 768px) and (max-width: 992px)',
   desktop: '(min-width: 993px) and (max-width: 1200px)',
   jumbo:   '(min-width: 1201px)'
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-responsive",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "An ember-cli addon that gives you a simple, Ember-aware way of dealing with media queries.",
   "directories": {
     "doc": "doc",

--- a/tests/unit/services/media-test.js
+++ b/tests/unit/services/media-test.js
@@ -20,7 +20,7 @@ test('it matches on init', function(assert) {
     match: sinon.stub()
   });
 
-  assert.ok(subject.match.withArgs('mobile','(max-width: 768px)').calledOnce);
+  assert.ok(subject.match.withArgs('mobile','(max-width: 767px)').calledOnce);
   assert.ok(subject.match.withArgs('jumbo','(min-width: 1201px)').calledOnce);
 });
 

--- a/tests/unit/services/media-test.js
+++ b/tests/unit/services/media-test.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
 
 const mediaRules = {
-  mobile:  '(max-width: 768px)',
+  mobile:  '(max-width: 767px)',
   jumbo:   '(min-width: 1201px)'
 };
 
@@ -58,7 +58,7 @@ test('classNames property returns matching matchers as classes', function(assert
 
 test('classNames is correctly bound to the matches property', function(assert) {
   var subject = this.subject({ breakpoints: mediaRules });
- 
+
   subject.match('one', 'all');
   assert.equal('media-one', subject.get('classNames'));
 


### PR DESCRIPTION
Update breakpoints.js with the same breakpoints that are generated when installing this addon on a project, i.e. the ones from [here](https://github.com/freshbooks/ember-responsive/blob/master/blueprints/ember-responsive/files/__root__/breakpoints.js).

Considering that the app/breakpoint.js generated by this addon overrides the default one, this should cause no harm.