### PR TITLE
Ensure addon does not use jQuery or shims

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,7 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    // Add options here
+    vendorFiles: { 'jquery.js': null, 'app-shims.js': null }
   });
 
   /*

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
     "ember-sinon": "^1.0.0",
-    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/release/shas/95355c4c56c0d09bde61d9744e856fd9359e833f.tgz",
+    "ember-source": "~3.0.0",
     "ember-source-channel-url": "^1.0.1",
     "ember-try": "^0.2.23",
     "eslint-plugin-ember": "^5.0.0",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -4,7 +4,6 @@
     "window",
     "location",
     "setTimeout",
-    "$",
     "-Promise",
     "define",
     "console",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2184,9 +2184,9 @@ ember-source-channel-url@^1.0.1:
   dependencies:
     got "^8.0.1"
 
-"ember-source@https://s3.amazonaws.com/builds.emberjs.com/release/shas/95355c4c56c0d09bde61d9744e856fd9359e833f.tgz":
-  version "3.0.0-release"
-  resolved "https://s3.amazonaws.com/builds.emberjs.com/release/shas/95355c4c56c0d09bde61d9744e856fd9359e833f.tgz#2e2617668fde35e00cebc0239c47c2d10e785954"
+ember-source@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.0.0.tgz#51811cae98d2ceec53bcfbaa876d02b2b5b2159f"
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"


### PR DESCRIPTION
The addon was already jquery-free, but with this change neither jquery or the old shims will be present, so if by any chance someone inadvertently uses jQuery in the future, the build will immediately fail.