### PR TITLE
Update media helper to recompute

### DIFF
--- a/addon/helpers/media.js
+++ b/addon/helpers/media.js
@@ -1,9 +1,18 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
+import { run } from '@ember/runloop';
 
 export default Helper.extend({
+  init() {
+    this._super(...arguments);
+    this.get('media').on('mediaChanged', () => {
+      this.recompute();
+    });
+  },
+
   media: service(),
+
   compute([prop]) {
     return get(this, `media.${prop}`);
   }

--- a/addon/services/media.js
+++ b/addon/services/media.js
@@ -6,6 +6,7 @@ import Service from '@ember/service';
 import { classify, dasherize } from '@ember/string';
 import nullMatchMedia from '../null-match-media';
 import { getOwner } from '@ember/application'
+import Evented from '@ember/object/evented';
 
 /**
 * Handles detecting and responding to media queries.
@@ -76,7 +77,7 @@ import { getOwner } from '@ember/application'
 * @class     Media
 * @extends   Ember.Object
 */
-export default Service.extend({
+export default Service.extend(Evented, {
   _mocked: Ember.testing,
   _mockedBreakpoint: 'desktop',
   /**
@@ -141,6 +142,14 @@ export default Service.extend({
     }).join(' ');
   }),
 
+  _triggerMediaChanged() {
+    this.trigger('mediaChanged', {});
+  },
+
+  _triggerEvent() {
+    run.once(this, this._triggerMediaChanged);
+  },
+
   /**
   * Adds a new matcher to the list.
   *
@@ -180,6 +189,7 @@ export default Service.extend({
       } else {
         this.get('matches').removeObject(name);
       }
+      this._triggerEvent();
     };
     this.get('listeners')[name] = listener;
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -2,29 +2,29 @@
   <p>
       This demonstrates the default media queries:
   </p>
-  <div class="view {{if media.isMobile 'active'}}">
-    {{#if media.isMobile}}
+  <div class="view {{if (media 'isMobile') 'active'}}">
+    {{#if (media 'isMobile')}}
         Mobile View!
     {{else}}
         Not Mobile View :(
     {{/if}}
   </div>
-  <div class="view {{if media.isTablet 'active'}}">
-    {{#if media.isTablet}}
+  <div class="view {{if (media 'isTablet') 'active'}}">
+    {{#if (media 'isTablet')}}
         Tablet View!
     {{else}}
         Not Tablet View :(
     {{/if}}
   </div>
-  <div class="view {{if media.isDesktop 'active'}}">
-    {{#if media.isDesktop}}
+  <div class="view {{if (media 'isDesktop') 'active'}}">
+    {{#if (media 'isDesktop')}}
         Desktop View!
     {{else}}
         Not Desktop View :(
     {{/if}}
   </div>
-  <div class="view {{if media.isJumbo 'active'}}">
-    {{#if media.isJumbo}}
+  <div class="view {{if (media 'isJumbo') 'active'}}">
+    {{#if (media 'isJumbo')}}
         Jumbo View!
     {{else}}
         Not Jumbo View :(

--- a/tests/integration/helpers/media-test.js
+++ b/tests/integration/helpers/media-test.js
@@ -10,7 +10,7 @@ module('Integration | Helper | media', function(hooks) {
     await render(hbs`{{#if (media 'isDesktop')}}Is desktop{{/if}}`);
     assert.equal(this.element.textContent.trim(), 'Is desktop');
 
-    await render(hbs`{{#if (media 'isTabled')}}Is desktop{{/if}}`);
+    await render(hbs`{{#if (media 'isTablet')}}Is desktop{{/if}}`);
     assert.equal(this.element.textContent.trim(), '');
 
     await render(hbs`{{media 'classNames'}}`);

--- a/tests/unit/services/media-test.js
+++ b/tests/unit/services/media-test.js
@@ -2,6 +2,8 @@ import { classify } from '@ember/string';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { setBreakpoint } from 'ember-responsive/test-support';
+import { run } from '@ember/runloop';
+
 const mediaRules = {
   mobile:  '(max-width: 767px)',
   jumbo:   '(min-width: 1201px)'
@@ -16,32 +18,41 @@ module('Unit | Service | media', function(hooks) {
 
   test('matchers can be added dynamically', function(assert) {
     var subject = this.owner.lookup('service:media');
-    subject.match('all', 'not all');
+    run(() => {
+      subject.match('all', 'not all');
+    });
 
     assert.equal(subject.get('all.matches'), false);
   });
 
   test('matchers have a corresponding isser', function(assert) {
     var subject = this.owner.lookup('service:media');
-    subject.match('mobile', 'not all');
+    run(() => {
+      subject.match('mobile', 'not all');
+    });
 
     assert.equal(subject.get('isMobile'), false);
   });
 
   test('matches property returns matching matchers', function(assert) {
     var subject = this.owner.lookup('service:media');
-    subject.match('mobile', 'all');
-    subject.match('all', 'all');
-    subject.match('none', 'not all');
+
+    run(() => {
+      subject.match('mobile', 'all');
+      subject.match('all', 'all');
+      subject.match('none', 'not all');
+    });
 
     assert.deepEqual(subject.get('matches').toArray(), ['mobile', 'all']);
   });
 
   test('classNames property returns matching matchers as classes', function(assert) {
     var subject = this.owner.lookup('service:media');
-    subject.match('mobileDevice', 'all');
-    subject.match('all', 'all');
-    subject.match('none', 'not all');
+    run(() => {
+      subject.match('mobileDevice', 'all');
+      subject.match('all', 'all');
+      subject.match('none', 'not all');
+    });
 
     assert.equal(subject.get('classNames'), 'media-mobile-device media-all');
   });
@@ -49,13 +60,20 @@ module('Unit | Service | media', function(hooks) {
   test('classNames is correctly bound to the matches property', function(assert) {
     var subject = this.owner.lookup('service:media');
 
-    subject.match('one', 'all');
+    run(() => {
+      subject.match('one', 'all');
+    });
     assert.equal(subject.get('classNames'), 'media-one');
 
-    subject.match('two', 'all');
+    run(() => {
+      subject.match('two', 'all');
+    });
     assert.equal(subject.get('classNames'), 'media-one media-two');
 
-    subject.match('one', 'none');
+
+    run(() => {
+      subject.match('one', 'none');
+    });
     assert.equal(subject.get('classNames'), 'media-two');
   });
 });


### PR DESCRIPTION
This adds an event which gets fired when the mql listeners find a match. This can be picked up by the media helper to fire a recompute.

This _should_ address https://github.com/freshbooks/ember-responsive/issues/125, but looking for feedback before I merge.