### PR TITLE
Fix matchers name collision and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ export default Controller.extend({
 
 In your templates you have access to the `media` helper that allows you to query breakpoints easily.
 
+**Note: this syntax is for the 3.x beta of ember-responsive**
 ```hbs
 {{#if (media 'isDesktop')}}
   Desktop view!
@@ -89,25 +90,23 @@ When updating this addon, make sure to run the generate command. Choose `no` to 
 
 `ember g ember-responsive`
 
+## Updating to 3.x (Still in beta)
+
+The major breaking changes to update to 3.x are so far:
+- Test helpers are now all covered by `setBreakpoint`
+- Calling media breakpoints in templates is now done with a helper. `{{media.isDesktop}}` -> `{{media 'isDesktop'}}`
+
 ## Testing Helpers
-This project provides several testing helpers to assist in testing
+This project provides a single test helper which works in both integration and acceptance tests to assist in testing
 content specific to different breakpoints.
 
 ### Acceptance Tests
-This project provides an acceptance testing helper to assist in testing
-content specific to different breakpoints.
-
-The provided testing helper *has to be added to start-app.js before the following example will work*.
-
-#### Changes required to start-app
 ```javascript
-// app/helpers/start-app.js
 ...
-import './responsive'; // You need to import helpers to use them in your tests.
+import { setBreakpoint } from 'ember-responsive/test-support';
+
 ...
-```
-#### Acceptance Helper Usage
-```javascript
+
 test('example test', function(assert) {
   setBreakpoint('mobile');
   visit('/');
@@ -118,28 +117,17 @@ test('example test', function(assert) {
 });
 ```
 
-The default breakpoint for testing defaults to `desktop`. You can modify this
-by changing `_defaultBreakpoint` in `tests/helpers/responsive.js`.
-
 ### Integration Tests
-Since the entire application isn't spun up for an integration tests, the `setBreakpoint`
-acceptance test helper won't work. In this case, you'll need to use the
-`setBreakpointForIntegrationTest` helper.
-
-To use the `setBreakpointForIntegrationTest` helper in an integration test:
-
 ```javascript
-import { moduleForComponent, test } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
-import { setBreakpointForIntegrationTest } from 'your-app-name/tests/helpers/responsive';
+...
+import { setBreakpoint } from 'ember-responsive/test-support';
 
-moduleForComponent('foo-bar', 'Integration | Component | foo bar', {
-  integration: true
-});
+...
 
 test('it renders', function(assert) {
-  setBreakpointForIntegrationTest(this, 'mobile');
-  this.render(hbs`{{foo-bar media=media}}`); // IMPORTANT: you must pass the media service
+  setBreakpoint('mobile');
+
+  this.render(hbs`{{your-component}}`);
 
   // assert something specific to mobile
 });

--- a/addon/services/media.js
+++ b/addon/services/media.js
@@ -100,6 +100,11 @@ export default Service.extend(Evented, {
   listeners: {},
 
   /**
+   * A hash of matchers by breakpoint name
+   */
+  matchers: {},
+
+  /**
   * The matcher to use for testing media queries.
   *
   * @property  matcher
@@ -120,9 +125,12 @@ export default Service.extend(Evented, {
     const breakpoints = getOwner(this).lookup('breakpoints:main');
     if (breakpoints) {
       Object.keys(breakpoints).forEach((name) => {
-        let cpName = `is${classify(name)}`;
+        const cpName = `is${classify(name)}`;
         defineProperty(this, cpName, computed('matches.[]', function () {
           return this.get('matches').indexOf(name) > -1;
+        }));
+        defineProperty(this, name, computed(cpName, function () {
+          return this.get(cpName);
         }));
         this.match(name, breakpoints[name]);
       });
@@ -176,13 +184,14 @@ export default Service.extend(Evented, {
       return;
     }
 
-    let matcher = this.get('mql')(query);
+    const matcher = this.get('mql')(query);
 
-    let listener = (matcher) => {
+    const listener = (matcher) => {
       if (this.get('isDestroyed')) {
         return;
       }
-      this.set(name, matcher);
+
+      this.set(`matchers.${name}`, matcher);
 
       if (matcher.matches) {
         this.get('matches').addObject(name);

--- a/tests/acceptance/acceptance-helpers-test.js
+++ b/tests/acceptance/acceptance-helpers-test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import { visit, find, waitFor } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setBreakpoint } from 'ember-responsive/test-support';
+
+module('Acceptance | acceptance helpers', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('changing breakpoints', async function(assert) {
+    await visit('/');
+
+    waitFor('.view.active');
+
+    setBreakpoint('jumbo');
+
+    assert.equal(find('.view.active').textContent.trim(), 'Jumbo View!');
+
+    setBreakpoint('desktop');
+
+    assert.equal(find('.view.active').textContent.trim(), 'Desktop View!');
+
+    setBreakpoint('tablet');
+
+    assert.equal(find('.view.active').textContent.trim(), 'Tablet View!');
+
+    assert.throws(() => {
+      setBreakpoint('unknown');
+    });
+  });
+});

--- a/tests/integration/helpers/media-test.js
+++ b/tests/integration/helpers/media-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { setBreakpoint } from 'ember-responsive/test-support';
 
 module('Integration | Helper | media', function(hooks) {
   setupRenderingTest(hooks);
@@ -10,10 +11,35 @@ module('Integration | Helper | media', function(hooks) {
     await render(hbs`{{#if (media 'isDesktop')}}Is desktop{{/if}}`);
     assert.equal(this.element.textContent.trim(), 'Is desktop');
 
-    await render(hbs`{{#if (media 'isTablet')}}Is desktop{{/if}}`);
+    await render(hbs`{{#if (media 'isTablet')}}Is tablet{{/if}}`);
     assert.equal(this.element.textContent.trim(), '');
 
     await render(hbs`{{media 'classNames'}}`);
     assert.equal(this.element.textContent.trim(), 'media-desktop');
+  });
+
+  test('it proxies to the media service without issers', async function(assert) {
+    await render(hbs`{{#if (media 'desktop')}}Is desktop{{/if}}`);
+    assert.equal(this.element.textContent.trim(), 'Is desktop');
+
+    await render(hbs`{{#if (media 'tablet')}}Is tablet{{/if}}`);
+    assert.equal(this.element.textContent.trim(), '');
+  });
+
+  test('it recomputes when breakpoints change', async function(assert) {
+    await render(hbs`
+      {{#if (media 'isDesktop')}}Is desktop{{/if}}
+      {{#if (media 'isTablet')}}Is tablet{{/if}}
+      {{#if (media 'isMobile')}}Is mobile{{/if}}
+    `);
+    assert.equal(this.element.textContent.trim(), 'Is desktop');
+
+    setBreakpoint('tablet');
+
+    assert.equal(this.element.textContent.trim(), 'Is tablet');
+
+    setBreakpoint('mobile');
+
+    assert.equal(this.element.textContent.trim(), 'Is mobile');
   });
 });

--- a/tests/unit/services/media-test.js
+++ b/tests/unit/services/media-test.js
@@ -22,7 +22,7 @@ module('Unit | Service | media', function(hooks) {
       subject.match('all', 'not all');
     });
 
-    assert.equal(subject.get('all.matches'), false);
+    assert.equal(subject.get('matchers.all.matches'), false);
   });
 
   test('matchers have a corresponding isser', function(assert) {


### PR DESCRIPTION
Doing a few things here to clean up the 3.x beta.

- This fixes an issue is people inadvertently try to use (media 'desktop') as the matcher fits that criteria.
- Additionally this updates the readme to make it more 3.x compatible.
- While I was at it, added a few more tests.