### PR TITLE
Ember 3.11 requires calls to super in `init()`

### DIFF
--- a/addon/services/media.js
+++ b/addon/services/media.js
@@ -121,6 +121,7 @@ export default Service.extend(Evented, {
    *
    */
   init() {
+    this._super(...arguments);
     const owner = getOwner(this);
     const breakpoints = getOwner(this).lookup('breakpoints:main');
     if (breakpoints) {


### PR DESCRIPTION
If an init function does not call `this._super` then Ember will error.

This is for https://github.com/freshbooks/ember-responsive/issues/144