### PR TITLE
Add multiple breakpoint test support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,35 @@ test('it renders', function(assert) {
 });
 ```
 
+### Multiple Breakpoints in Tests
+
+You can set multiple breakpoints to the helper.  This is useful if your `breakpoints.js` file defines breakpoints
+that overlap.
+
+```javascript
+// in app/breakpoints.js
+export default {
+  tablet:  '(min-width: 768px)',
+  desktop: '(min-width: 992px)',
+  jumbo:   '(min-width: 1201px)'
+};
+
+// in test file
+...
+import { setBreakpoint } from 'ember-responsive/test-support';
+
+...
+
+test('it renders', function(assert) {
+  setBreakpoint(['tablet', 'desktop']);
+
+  this.render(hbs`{{your-component}}`);
+
+  // assert something specific to desktop, i.e. sizes 992px - 1201px
+  // `isTablet` and `isDesktop` will both return true
+});
+```
+
 ## Tests
 
 To run the tests, after cloning do:

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,21 +1,27 @@
 import { getContext, settled } from '@ember/test-helpers';
 import { run } from '@ember/runloop';
 
-export function setBreakpoint(breakpointName) {
+export function setBreakpoint(breakpoint) {
+  let breakpointArray = Array.isArray(breakpoint) ? breakpoint : [breakpoint];
   let { owner } = getContext();
   let breakpoints = owner.lookup('breakpoints:main');
   let media = owner.lookup('service:media');
-  if (breakpointName === 'auto') {
-    media.set('_mocked', false);
-    return;
+
+  for (let breakpointName of breakpointArray) {
+    if (breakpointName === 'auto') {
+      media.set('_mocked', false);
+      return;
+    }
+
+    if (Object.keys(breakpoints).indexOf(breakpointName) === -1) {
+      throw new Error(`Breakpoint "${breakpointName}" is not defined in your breakpoints file`);
+    }
   }
-  if (Object.keys(breakpoints).indexOf(breakpointName) === -1) {
-    throw new Error(`Breakpoint "${breakpointName}" is not defined in your breakpoints file`);
-  }
+
   let matches = media.get('matches');
   run(() => {
     matches.clear();
-    matches.addObject(breakpointName);
+    matches.addObjects(breakpointArray);
     media._triggerMediaChanged();
   });
   return settled();

--- a/tests/integration/testing-helpers-test.js
+++ b/tests/integration/testing-helpers-test.js
@@ -64,4 +64,13 @@ module('Test Helpers | setBreakpoint', function(hooks) {
     await setBreakpoint('desktop');
     assert.dom('#dom-target').hasText('Desktop');
   });
+
+  test('`setBreakpoint` can accept an array of breakpoints', async function(assert) {
+    setBreakpoint(['mobile', 'tablet']);
+    let subject = this.owner.factoryFor('component:dummy-component').create();
+
+    assert.equal(subject.get('media.isDesktop'), false);
+    assert.equal(subject.get('media.isTablet'), true);
+    assert.equal(subject.get('media.isMobile'), true);
+  });
 });


### PR DESCRIPTION
`setBreakpoint` now also accepts an array, so you can set multiple breakpoints.  E.g.

```
setBreakpoint(['tablet', 'desktop'])

// isTablet === true
// isDesktop === true 
```

Fixes #154 