### PR TITLE
use matcher.addEventListener, if possible

### DIFF
--- a/addon/services/media.js
+++ b/addon/services/media.js
@@ -228,7 +228,11 @@ export default class MediaService extends Service.extend(Evented) {
     };
     this.listeners[name] = listener;
 
-    if (matcher.addListener) {
+    if (typeof matcher.addEventListener === "function") {
+      matcher.addEventListener("change", function(matcher){
+        run(null, listener, matcher);
+      });
+    } else if (matcher.addListener) {
       matcher.addListener(function(matcher){
         run(null, listener, matcher);
       });


### PR DESCRIPTION
The current version using addListener is broken on Chrome on the iPad, which is breaking my app.