### PR TITLE
Fix export of media helper

### DIFF
--- a/app/helpers/media.js
+++ b/app/helpers/media.js
@@ -1,1 +1,1 @@
-export { default, media } from 'ember-responsive/helpers/media';
+export { default } from 'ember-responsive/helpers/media';


### PR DESCRIPTION
Ember CLI was doing this double export as part of the blueprint for a
while, but it makes embroider sad. I've removed the non-existent
re-export of media.