### PR TITLE
Media export does not exist

### DIFF
--- a/app/helpers/media.js
+++ b/app/helpers/media.js
@@ -1,1 +1,1 @@
-export { default, media } from 'ember-responsive/helpers/media';
+export { default } from 'ember-responsive/helpers/media';


### PR DESCRIPTION
Using embroider I get this warning when building
```
WARNING in ./helpers/media.js 1:0-80
export 'media' (reexported as 'media') was not found in '../node_modules/ember-responsive/helpers/media' (possible exports: default)
```
The addon still works, but removing the import of `media` here stops this warning and does not seem to affect usage of the addon, but maybe I have overlooked something?