### PR TITLE
Add @ember/string dependency to ember-responsive

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.11",
-    "tracked-built-ins": "^3.1.0"
+    "tracked-built-ins": "^3.1.0",
+    "@ember/string": "^3.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,6 +1139,13 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
+"@ember/string@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@ember/string/-/string-3.0.1.tgz#42cf032031a4432c2dd69c327ae1876d2c13df9c"
+  integrity sha512-ntnmXS+upOWVXE+rVw2l03DjdMnaGdWbYVUxUBuPJqnIGZu2XFRsoXc7E6mOw62s8i1Xh1RgTuFHN41QGIolEQ==
+  dependencies:
+    ember-cli-babel "^7.26.6"
+
 "@ember/test-helpers@^2.8.1":
   version "2.9.3"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.9.3.tgz#c2a9d6ab1c367af92cf1a334f97eb19b8e06e6e1"


### PR DESCRIPTION
The `ember-beta` scenario now installs ember 5.0.0-beta.1, which is failing because the `@ember/string` dependency needs to be explicitly installed with ember 5.